### PR TITLE
Update header tagline text

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ import { Header } from '@/components/header'
 import './globals.css'
 
 export const metadata: Metadata = {
-    title: 'Fx64b - Software Engineer & Developer',
+    title: 'Fx64b - Software Engineer & Security Enthusiast',
     description:
         'Software engineer from Switzerland specializing in React, Next.js, TypeScript, and Go.',
 }

--- a/components/hero-section.tsx
+++ b/components/hero-section.tsx
@@ -37,7 +37,7 @@ export function HeroSection() {
                         Software Engineer
                         <br />
                         <span className="from-foreground to-foreground/70 bg-gradient-to-r bg-clip-text text-transparent">
-                            & Developer
+                            & Security Enthusiast
                         </span>
                     </h1>
 


### PR DESCRIPTION
Changed from "Software Engineer & Developer" to better reflect current focus on cybersecurity exploration. Updated both hero section and page metadata.